### PR TITLE
Bugfix: inifinite loop when nan in torch permutation solver

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,11 +11,7 @@ jobs:
       max-parallel: 12
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        exclude:
-          # excludes macos/python3.6 since this combination is not available
-          - os: macos-latest
-            python-version: 3.6
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
     - name: Checkout submodules

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 12
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Checkout submodules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,11 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
-Nothing yet.
+Bugfix
+~~~~~~
+
+- For pytorch, the permutation solver would go in an infinite loop when
+  a nan value was present. Corrected and test added.
 
 `0.1.0`_ - 2021-10-28
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 `Unreleased`_
 -------------
 
+New
+~~~
+
+- Removed CI for python 3.6, Added for python 3.10
+
 Bugfix
 ~~~~~~
 

--- a/fast_bss_eval/numpy/cgd.py
+++ b/fast_bss_eval/numpy/cgd.py
@@ -86,7 +86,7 @@ class CirculantPreconditionerOperator:
         col_precond = optimal_symmetric_circulant_precond_column(toeplitz_col)
         C = np.fft.rfft(col_precond, axis=-1)
         # complex pointwise inverse
-        self.C = C.conj() / clamp(C.real ** 2 + C.imag ** 2, min=1e-6)
+        self.C = C.conj() / clamp(C.real**2 + C.imag**2, min=1e-6)
         self.n = col_precond.shape[-1]
 
         self._shape = col_precond.shape[:-1] + (self.n, self.n)

--- a/fast_bss_eval/numpy/metrics.py
+++ b/fast_bss_eval/numpy/metrics.py
@@ -120,7 +120,7 @@ def compute_stats(
     Y = fft.rfft(y, n=n_fft, axis=-1)
 
     # autocorrelation function
-    acf = fft.irfft(X.real ** 2 + X.imag ** 2, n=n_fft)
+    acf = fft.irfft(X.real**2 + X.imag**2, n=n_fft)
 
     # cross-correlation
     if pairwise:

--- a/fast_bss_eval/torch/cgd.py
+++ b/fast_bss_eval/torch/cgd.py
@@ -87,7 +87,7 @@ class CirculantPreconditionerOperator:
         col_precond = optimal_symmetric_circulant_precond_column(toeplitz_col)
         C = torch.fft.rfft(col_precond, dim=-1)
         # complex pointwise inverse
-        self.C = C.conj() / torch.clamp(C.real ** 2 + C.imag ** 2, min=1e-6)
+        self.C = C.conj() / torch.clamp(C.real**2 + C.imag**2, min=1e-6)
         self.n = col_precond.shape[-1]
 
         self._shape = col_precond.shape[:-1] + (self.n, self.n)

--- a/fast_bss_eval/torch/helpers.py
+++ b/fast_bss_eval/torch/helpers.py
@@ -21,7 +21,9 @@
 from typing import Optional, Tuple
 
 import numpy as np
+
 import torch
+
 from .hungarian import linear_sum_assignment
 
 
@@ -112,6 +114,9 @@ def _linear_sum_assignment_with_inf(
     https://github.com/scipy/scipy/issues/6900
     to handle infinite entries in the cost matrix.
     """
+
+    if cost_matrix.numel() == 0:
+        return torch.zeros(0, dtype=torch.int64), torch.zeros(0, dtype=torch.int64)
 
     min_inf = torch.isneginf(cost_matrix).any()
     max_inf = torch.isposinf(cost_matrix).any()

--- a/fast_bss_eval/torch/hungarian.py
+++ b/fast_bss_eval/torch/hungarian.py
@@ -79,6 +79,9 @@ def linear_sum_assignment(
     5. https://en.wikipedia.org/wiki/Hungarian_algorithm
     """
 
+    if torch.any(torch.isnan(cost_matrix)):
+        raise ValueError("matrix contains invalid numeric entries")
+
     if len(cost_matrix.shape) != 2:
         raise ValueError(
             "expected a matrix (2-d array), got a %r array" % (cost_matrix.shape,)

--- a/fast_bss_eval/torch/metrics.py
+++ b/fast_bss_eval/torch/metrics.py
@@ -119,7 +119,7 @@ def compute_stats(
     Y = torch.fft.rfft(y, n=n_fft, dim=-1)
 
     # autocorrelation function
-    acf = torch.fft.irfft(X.real ** 2 + X.imag ** 2, n=n_fft)
+    acf = torch.fft.irfft(X.real**2 + X.imag**2, n=n_fft)
 
     # cross-correlation
     if pairwise:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,5 @@ torch>=1.9
 mir_eval
 pytest
 pytest-cov
+pytest-timeout
 -e .

--- a/tests/test_hungarian.py
+++ b/tests/test_hungarian.py
@@ -41,6 +41,7 @@ def test_nan(seed, backend, n_chan=2, n_samples=4000):
     with pytest.raises(ValueError):
         sdr, sir, sar, perm = fast_bss_eval.bss_eval_sources(ref, est)
 
+
 def test_empty_input():
     cost_matrix = torch.zeros(0)
     out1, out2 = _linear_sum_assignment_with_inf(cost_matrix)

--- a/tests/test_hungarian.py
+++ b/tests/test_hungarian.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.optimize import linear_sum_assignment
 import fast_bss_eval
 import fast_bss_eval.torch.hungarian as hungarian
+from fast_bss_eval.torch.helpers import _linear_sum_assignment_with_inf
 
 
 @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4, 5])
@@ -39,3 +40,10 @@ def test_nan(seed, backend, n_chan=2, n_samples=4000):
 
     with pytest.raises(ValueError):
         sdr, sir, sar, perm = fast_bss_eval.bss_eval_sources(ref, est)
+
+def test_empty_input():
+    cost_matrix = torch.zeros(0)
+    out1, out2 = _linear_sum_assignment_with_inf(cost_matrix)
+
+    assert out1.numel() == 0
+    assert out2.numel() == 0

--- a/tests/test_hungarian.py
+++ b/tests/test_hungarian.py
@@ -2,8 +2,25 @@ import pytest
 import torch
 import numpy as np
 from scipy.optimize import linear_sum_assignment
+import fast_bss_eval
 import fast_bss_eval.torch.hungarian as hungarian
 
+import signal
+
+class Timeout:
+    """
+    A class to catch timeout errors for the nan problem
+    """
+    def __init__(self, seconds=1, error_message='Timeout'):
+        self.seconds = seconds
+        self.error_message = error_message
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.handle_timeout)
+        signal.alarm(self.seconds)
+    def __exit__(self, type, value, traceback):
+        signal.alarm(0)
 
 @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize("rows", [2, 3, 4, 5, 6, 10])
@@ -19,3 +36,25 @@ def test_hungarian(seed, rows, cols):
     assert np.all(row2 - row1.cpu().numpy() == 0) and np.all(
         col2 - col1.cpu().numpy() == 0
     )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+@pytest.mark.parametrize("backend", ["numpy", "torch"])
+def test_nan(seed, backend, n_chan=2, n_samples=4000):
+
+    est = torch.zeros((n_chan, n_samples)).normal_()
+    ref = torch.zeros((n_chan, n_samples)).normal_()
+
+    # add one nan
+    est[0, n_samples // 2] = torch.nan
+
+    if backend == "numpy":
+        est = est.numpy()
+        ref = ref.numpy()
+
+    with pytest.raises(ValueError):
+        try:
+            with Timeout(seconds=1):
+                sdr, sir, sar, perm = fast_bss_eval.bss_eval_sources(ref, est)
+        except TimeoutError:
+            assert False, "Test nan: timeout exceeded"

--- a/tests/test_si_sdr.py
+++ b/tests/test_si_sdr.py
@@ -78,23 +78,22 @@ def _random_input_pairs(
 
 
 @pytest.mark.parametrize(
-    "is_torch,is_fp32,rand_perm,tol",
+    "is_torch,is_fp32,rand_perm,tol,nchan",
     [
-        (True, True, True, 1e-1),
-        (True, True, False, 1e-1),
-        (True, False, False, 1e-5),
-        (True, False, True, 1e-5),
-        (False, False, True, 1e-5),
-        (False, True, True, 1e-1),
-        (False, True, False, 1e-1),
-        (False, False, False, 1e-5),
+        (True, True, True, 1e-1, 4),
+        (True, True, False, 1e-1, 4),
+        (True, False, False, 1e-5, 4),
+        (True, False, True, 1e-5, 4),
+        (False, False, True, 1e-5, 4),
+        (False, True, True, 1e-1, 4),
+        (False, True, False, 1e-1, 4),
+        (False, False, False, 1e-5, 4),
     ],
 )
-def test_si_sdr(is_torch, is_fp32, rand_perm, tol):
+def test_si_sdr(is_torch, is_fp32, rand_perm, tol, nchan):
     np.random.seed(10)
 
     nbatch = 10
-    nchan = 4
     nsamples = 16000
 
     for trial in range(10):

--- a/tests/test_si_sdr.py
+++ b/tests/test_si_sdr.py
@@ -33,9 +33,9 @@ def _random_input_pairs(
     # mixing coefficients
     # make sure the diagonal of alpha is larger than off-diag coeffecients
     alpha = np.random.rand(nbatch, nchan, nchan) - 0.5 + 2.0 * np.eye(nchan)
-    alpha2 = alpha ** 2
+    alpha2 = alpha**2
     beta = np.random.randn(nbatch, nchan)
-    beta2 = beta ** 2
+    beta2 = beta**2
 
     alpha2_diag = np.diagonal(alpha2, axis1=-2, axis2=-1)
     alpha2_sum = alpha2.sum(axis=-1)


### PR DESCRIPTION
This PR corrects a bug in the torch permutation solver whereas when a nan is present in the cost matrix, the algorithm will go in an infinite loop.

A test was added to check this case in the future.